### PR TITLE
Nrped upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Godeps/_workspace
 *.key
 *.pem
 gen_certificate/gen_certificate
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,9 @@ deps:
 test: deps
 	go test ./...
 
+check_nrpe: deps
+	@mkdir -p bin
+	go build -C check_nrpe -o ../bin/check_nrpe
+
 clean:
 	rm -rf bin

--- a/common/command.go
+++ b/common/command.go
@@ -1,0 +1,136 @@
+package common
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+// Command represents command name and argument list
+type NrpeCommand struct {
+	Name string
+	Args []string
+}
+
+// NewCommand creates Command object with the given name and optional argument list
+func NewNrpeCommand(name string, args ...string) NrpeCommand {
+	return NrpeCommand{
+		Name: name,
+		Args: args,
+	}
+}
+
+// toStatusLine convers Command content to a formated string ready to send to nrped (args separated by !)
+func (c *NrpeCommand) ToCommandLine() string {
+	if c.Args != nil && len(c.Args) > 0 {
+		args := strings.Join(c.Args, "!")
+		return c.Name + "!" + args
+	}
+
+	return c.Name
+}
+
+// convert NrpeCommand to human readable string
+func (cmd *NrpeCommand) ToString() string {
+	return strings.Join(append([]string{cmd.Name}, cmd.Args...), " ")
+}
+
+/*
+	 Execute the command send as object with parameters from cmd_params.
+	   Convert $ARGx$ from caller to value from cmd_params.args[x] if it exists.
+	   Nasty_chars are checked on each parameter: if some found return message and critical status to querier.
+	   return:
+	    * uint16: exit status from command execution STATUS_OK, STATUS_WARNING, STATUS_CRITICAL, STATUS_UNKNOWN
+		*[]byte: content of stdout.
+*/
+func (c *NrpeCommand) Execute(cmd_params *NrpeCommand, nasty_chars string, logger log.Logger) (int16, []byte) {
+	cmd := NrpeCommand{
+		Name: c.Name,
+	}
+	cmd.Args = make([]string, len(c.Args))
+	// have to substitute $ARGx$ with command parameter x if it exists!
+	regex := *regexp.MustCompile(`^\$ARG(\d+)\$$`)
+
+	for i := range c.Args {
+		res := regex.FindStringSubmatch(c.Args[i])
+		if len(res) > 0 {
+			if arg_num, err := strconv.Atoi(res[1]); err == nil {
+				if arg_num >= 1 && arg_num <= len(c.Args) && arg_num <= len(cmd_params.Args) {
+					cmd.Args[i] = cmd_params.Args[arg_num-1]
+				}
+			}
+			// if
+
+		} else {
+			cmd.Args[i] = c.Args[i]
+		}
+		if strings.ContainsAny(cmd.Args[i], nasty_chars) {
+			if logger != nil {
+				level.Debug(logger).Log("msg", "command parameter contains nasty chars", "index", i, "param", cmd.Args[i])
+			}
+			return STATE_CRITICAL, []byte("nasty chars found")
+		}
+	}
+
+	cmdLine := exec.Command(cmd.Name, cmd.Args...)
+	if logger != nil {
+		level.Debug(logger).Log("msg", "will launch command", "cmd", strings.Join(cmdLine.Args, " "))
+	}
+	cmd_stdout, _ := cmdLine.StdoutPipe()
+	if err := cmdLine.Start(); err != nil {
+		return int16(2), []byte(fmt.Sprintf("%s", err))
+	}
+	stdout_reader := bufio.NewReader(cmd_stdout)
+	read_line, _, _ := stdout_reader.ReadLine()
+	result := cmdLine.Wait()
+	status := 0
+	if result != nil {
+		status = result.(*exec.ExitError).ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+	}
+	if logger != nil {
+		level.Debug(logger).Log("msg", "command execute successfully", "exit_code", status, "stdout", read_line)
+	}
+	return int16(status), read_line
+}
+
+/*
+	 build a NrpeCommand from a command line sent by a nrpe query.
+	   args are separated by rune '!'
+	   return:
+		NrpeCommand
+*/
+func CommandLine2Cmd(cmdline string) *NrpeCommand {
+	var cmd NrpeCommand
+	elmts := strings.Split(cmdline, "!")
+	if len(elmts) > 1 {
+		cmd = NewNrpeCommand(elmts[0], elmts[1:]...)
+	} else {
+		cmd = NewNrpeCommand(elmts[0])
+	}
+	return &cmd
+}
+
+/*
+	 build a NrpeCommand from a command line in human readable format (space separated).
+	   return:
+		NrpeCommand
+*/
+func BuildNrpeCommand(command string) NrpeCommand {
+	var cmd NrpeCommand
+
+	elmts := strings.Fields(command)
+
+	if len(elmts) > 1 {
+		cmd = NewNrpeCommand(elmts[0], elmts[1:]...)
+	} else {
+		cmd = NewNrpeCommand(elmts[0])
+	}
+	return cmd
+}

--- a/common/common.go
+++ b/common/common.go
@@ -1,21 +1,15 @@
 package common
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
-	"math/rand"
 	"net"
 	"os"
-	"os/exec"
-	"strings"
-	"syscall"
-	"time"
 )
 
-//define states
+// define states
 const (
 	STATE_OK       = 0
 	STATE_WARNING  = 1
@@ -23,54 +17,133 @@ const (
 	STATE_UNKNOWN  = 3
 )
 
-//packet type
+func MessageState(state int) string {
+
+	message_state := []string{
+		"STATE_OK",
+		"STATE_WARNING",
+		"STATE_CRITICAL",
+		"STATE_UNKNOWN",
+	}
+	if state < STATE_OK || state > STATE_UNKNOWN {
+		state = STATE_UNKNOWN
+	}
+	return message_state[state]
+}
+
+// packet type
 const (
 	QUERY_PACKET    = 1
 	RESPONSE_PACKET = 2
 )
 
-//packet version
+// packet version
 const (
 	NRPE_PACKET_VERSION_1 = 1
 	NRPE_PACKET_VERSION_2 = 2
-	NRPE_PACKET_VERSION_3 = 3 /* packet version identifier */
+	NRPE_PACKET_VERSION_3 = 3
+	NRPE_PACKET_VERSION_4 = 4 /* packet version identifier */
 )
 
-//max buffer size
-const MAX_PACKETBUFFER_LENGTH = 1024
+// max buffer size
+const MAX_PACKETBUFFER_V2_LENGTH = 1024
+const MAX_PACKETBUFFER_V3_LENGTH = 1024 * 64
 
 const HELLO_COMMAND = "version"
+const EMPTY_COMMAND = "_NRPE_CHECK"
 
 const PROGRAM_VERSION = "0.02"
 
-type NrpePacket struct {
+type NrpePacket interface {
+	Version() int16
+	Type() int16
+	GetCommandBuffer() string
+	GetCRC32() uint32
+	ResultCode() int
+
+	SetType(pkt_type int16)
+	SetResultCode(result int16)
+	SetCommand(cmd string)
+
+	DoCRC32() (uint32, error)
+	Encode() []byte
+
+	PrepareToSend(pkt_type int16) error
+	SendPacket(conn net.Conn) error
+}
+
+type nrpePacketCommonHeader struct {
 	PacketVersion int16
 	PacketType    int16
 	CRC32Value    uint32
 	ResultCode    int16
-	CommandBuffer [MAX_PACKETBUFFER_LENGTH]byte
+}
+
+type nrpePacketV2Header struct {
+	Common        nrpePacketCommonHeader
+	CommandBuffer [MAX_PACKETBUFFER_V2_LENGTH]byte
 	Trailer       int16
 }
 
-func CheckError(err error) {
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Fatal error: %s", err.Error())
-		os.Exit(1)
-	}
+type nrpePacketV2 struct {
+	Header   nrpePacketV2Header
+	AllBytes []byte
 }
 
-//todo return error as well
-func ReceivePacket(conn net.Conn) (NrpePacket, error) {
-	pkt_rcv := new(NrpePacket)
-	if err := binary.Read(conn, binary.BigEndian, pkt_rcv); err != nil {
-		return *pkt_rcv, err
-	}
-	return *pkt_rcv, nil
+type nrpePacketV3Header struct {
+	Common       nrpePacketCommonHeader
+	Alignment    int16
+	BufferLength uint32
 }
 
-func SendPacket(conn net.Conn, pkt_send NrpePacket) error {
+type nrpePacketV3 struct {
+	Header        nrpePacketV3Header
+	CommandBuffer []byte
+	AllBytes      []byte
+}
+
+// **********************************************************************************************
+//
+// packetV3 implements NrepPacket
+//
+// **********************************************************************************************
+func (pkt *nrpePacketV3) Version() int16 {
+	return pkt.Header.Common.PacketVersion
+}
+
+func (pkt *nrpePacketV3) Type() int16 {
+	return pkt.Header.Common.PacketType
+}
+
+func (pkt *nrpePacketV3) ResultCode() int {
+	return int(pkt.Header.Common.ResultCode)
+}
+
+func (pkt *nrpePacketV3) GetCommandBuffer() string {
+	// return string(pkt.CommandBuffer[:])
+	// remove last \x00 char
+	return string(bytes.Trim(pkt.CommandBuffer[:], "\x00"))
+}
+
+func (pkt *nrpePacketV3) GetCRC32() uint32 {
+	return pkt.Header.Common.CRC32Value
+}
+
+func (pkt *nrpePacketV3) SetType(pkt_type int16) {
+	pkt.Header.Common.PacketType = pkt_type
+}
+
+func (pkt *nrpePacketV3) SetResultCode(result int16) {
+	pkt.Header.Common.ResultCode = result
+}
+
+func (pkt *nrpePacketV3) SetCommand(cmd string) {
+	copy(pkt.CommandBuffer[:], cmd)
+}
+
+func (pkt *nrpePacketV3) SendPacket(conn net.Conn) error {
 	buf := new(bytes.Buffer)
-	if err := binary.Write(buf, binary.BigEndian, &pkt_send); err != nil {
+	if err := binary.Write(buf, binary.BigEndian, &pkt.AllBytes); err != nil {
 		fmt.Println(err)
 	}
 	if _, err := conn.Write([]byte(buf.Bytes())); err != nil {
@@ -79,83 +152,266 @@ func SendPacket(conn net.Conn, pkt_send NrpePacket) error {
 	return nil
 }
 
-func PrepareToSend(cmd string, pkt_type int16) NrpePacket {
-	pkt_send, _ := MakeNrpePacket()
-	if pkt_type == RESPONSE_PACKET { //its a response
-		pkt_send.PacketType = RESPONSE_PACKET
-		if cmd == HELLO_COMMAND {
-			copy(pkt_send.CommandBuffer[:], PROGRAM_VERSION)
-			pkt_send.ResultCode = STATE_OK
-		}
-	} else { // Query Packet
-		pkt_send.ResultCode = STATE_OK
-		pkt_send.PacketType = QUERY_PACKET
-		copy(pkt_send.CommandBuffer[:], cmd)
+func (pkt *nrpePacketV3) DoCRC32() (uint32, error) {
+	var err error
+	pkt.Header.Common.CRC32Value = 0
+	// build a temporary []byte without crc32 value
+	pkt.AllBytes = pkt.Encode()
+
+	pkt.Header.Common.CRC32Value = crc32.ChecksumIEEE(pkt.AllBytes)
+	if pkt.Header.Common.CRC32Value == 0 {
+		err = fmt.Errorf("invalid CRC32")
 	}
-	pkt_send.CRC32Value, _ = DoCRC32(&pkt_send)
-	return pkt_send
+	// now we have crc32 value, we can build the final []byte
+	pkt.AllBytes = pkt.Encode()
+
+	return pkt.Header.Common.CRC32Value, err
 }
 
-func MakeNrpePacket() (NrpePacket, error) {
-	pkt := new(NrpePacket)
-	buf := make([]byte, len(pkt.Encode()))
-
-	char := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-	rand.Seed(time.Now().UTC().UnixNano())
-	for i := 0; i < len(buf); i++ {
-		buf[i] = char[rand.Intn(len(char)-1)]
-	}
-	if err := binary.Read(bytes.NewReader(buf), binary.BigEndian, pkt); err != nil {
-		return *pkt, err
-	}
-
-	pkt.PacketVersion = NRPE_PACKET_VERSION_2
-	pkt.CRC32Value = 0
-	pkt.ResultCode = STATE_UNKNOWN
-	for i := range pkt.CommandBuffer {
-		pkt.CommandBuffer[i] = '\x00'
-	}
-	return *pkt, nil
-}
-
-func DoCRC32(pkt *NrpePacket) (uint32, error) {
-	pkt.CRC32Value = 0
-	pktbytes := pkt.Encode()
-
-	return crc32.ChecksumIEEE(pktbytes), nil
-}
-
-func (pkt *NrpePacket) Encode() []byte {
+func (pkt *nrpePacketV3) Encode() []byte {
 	writer := new(bytes.Buffer)
-	binary.Write(writer, binary.BigEndian, pkt.PacketVersion)
-	binary.Write(writer, binary.BigEndian, pkt.PacketType)
-	binary.Write(writer, binary.BigEndian, pkt.CRC32Value)
-	binary.Write(writer, binary.BigEndian, pkt.ResultCode)
+	binary.Write(writer, binary.BigEndian, pkt.Header.Common.PacketVersion)
+	binary.Write(writer, binary.BigEndian, pkt.Header.Common.PacketType)
+	binary.Write(writer, binary.BigEndian, pkt.Header.Common.CRC32Value)
+	binary.Write(writer, binary.BigEndian, pkt.Header.Common.ResultCode)
+	binary.Write(writer, binary.BigEndian, pkt.Header.Alignment)
+	binary.Write(writer, binary.BigEndian, pkt.Header.BufferLength)
 	writer.Write([]byte(pkt.CommandBuffer[:]))
-	binary.Write(writer, binary.BigEndian, pkt.Trailer)
+
 	return writer.Bytes()
 }
 
-// count the numbers of bytes until 0 is found
-func GetLen(b []byte) int {
-	return bytes.Index(b, []byte{0})
+func (pkt *nrpePacketV3) PrepareToSend(pkt_type int16) error {
+
+	pkt.SetType(pkt_type)
+
+	if _, err := pkt.DoCRC32(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func ExecuteCommand(cmd_in string) (int16, []byte) {
-	parts := strings.Fields(cmd_in)
-	head := parts[0]
-	parts = parts[1:]
-	cmd := exec.Command(head, parts...)
-	cmd_stdout, _ := cmd.StdoutPipe()
-	if err := cmd.Start(); err != nil {
-		return int16(2), nil
+// todo return error as well
+func ReceivePacketV3(conn net.Conn, pkt_std *nrpePacketCommonHeader) (NrpePacket, error) {
+	pkt_recv := new(nrpePacketV3)
+	pkt_recv.Header.Common.PacketVersion = pkt_std.PacketVersion
+	pkt_recv.Header.Common.PacketType = pkt_std.PacketType
+	pkt_recv.Header.Common.CRC32Value = pkt_std.CRC32Value
+	pkt_recv.Header.Common.ResultCode = pkt_std.ResultCode
+	if err := binary.Read(conn, binary.BigEndian, &pkt_recv.Header.Alignment); err != nil {
+		return pkt_recv, err
 	}
-	stdout_reader := bufio.NewReader(cmd_stdout)
-	read_line, _, _ := stdout_reader.ReadLine()
-	result := cmd.Wait()
-	status := 0
-	if result != nil {
-		status = result.(*exec.ExitError).ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+	if err := binary.Read(conn, binary.BigEndian, &pkt_recv.Header.BufferLength); err != nil {
+		return pkt_recv, err
 	}
-	return int16(status), read_line
+
+	pkt_recv.CommandBuffer = make([]byte, pkt_recv.Header.BufferLength)
+	if err := binary.Read(conn, binary.BigEndian, &pkt_recv.CommandBuffer); err != nil {
+		return pkt_recv, err
+	}
+
+	return pkt_recv, nil
+}
+
+// **********************************************************************************************
+//
+// packetV2 implements NrepPacket
+//
+// **********************************************************************************************
+func (pkt *nrpePacketV2) Version() int16 {
+	return pkt.Header.Common.PacketVersion
+}
+
+func (pkt *nrpePacketV2) Type() int16 {
+	return pkt.Header.Common.PacketType
+}
+
+func (pkt *nrpePacketV2) ResultCode() int {
+	return int(pkt.Header.Common.ResultCode)
+}
+
+func (pkt *nrpePacketV2) GetCommandBuffer() string {
+	// remove all last \x00 runes
+	return string(bytes.Trim(pkt.Header.CommandBuffer[:], "\x00"))
+}
+func (pkt *nrpePacketV2) GetCRC32() uint32 {
+	return pkt.Header.Common.CRC32Value
+}
+
+func (pkt *nrpePacketV2) SetType(pkt_type int16) {
+	pkt.Header.Common.PacketType = pkt_type
+}
+
+func (pkt *nrpePacketV2) SetResultCode(result int16) {
+	pkt.Header.Common.ResultCode = result
+}
+
+func (pkt *nrpePacketV2) SetCommand(cmd string) {
+	copy(pkt.Header.CommandBuffer[:], cmd)
+}
+
+func (pkt *nrpePacketV2) SendPacket(conn net.Conn) error {
+	buf := new(bytes.Buffer)
+	if err := binary.Write(buf, binary.BigEndian, &pkt.AllBytes); err != nil {
+		fmt.Println(err)
+	}
+	if _, err := conn.Write([]byte(buf.Bytes())); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (pkt *nrpePacketV2) DoCRC32() (uint32, error) {
+	var err error
+	pkt.Header.Common.CRC32Value = 0
+	// build a temporary []byte without crc32 value
+	pkt.AllBytes = pkt.Encode()
+
+	pkt.Header.Common.CRC32Value = crc32.ChecksumIEEE(pkt.AllBytes)
+	if pkt.Header.Common.CRC32Value == 0 {
+		err = fmt.Errorf("invalid CRC32")
+	}
+	// now we have crc32 value, we can build the final []byte
+	pkt.AllBytes = pkt.Encode()
+
+	return pkt.Header.Common.CRC32Value, err
+}
+
+func (pkt *nrpePacketV2) Encode() []byte {
+	writer := new(bytes.Buffer)
+	binary.Write(writer, binary.BigEndian, pkt.Header.Common.PacketVersion)
+	binary.Write(writer, binary.BigEndian, pkt.Header.Common.PacketType)
+	binary.Write(writer, binary.BigEndian, pkt.Header.Common.CRC32Value)
+	binary.Write(writer, binary.BigEndian, pkt.Header.Common.ResultCode)
+	writer.Write([]byte(pkt.Header.CommandBuffer[:]))
+	binary.Write(writer, binary.BigEndian, pkt.Header.Trailer)
+	pkt.AllBytes = writer.Bytes()
+	return pkt.AllBytes
+}
+
+func (pkt *nrpePacketV2) PrepareToSend(pkt_type int16) error {
+
+	pkt.SetType(pkt_type)
+	// pkt.SetResultCode(STATE_OK)
+	// if pkt_type == RESPONSE_PACKET && cmd == HELLO_COMMAND { //its a response
+	// 	pkt.SetCommand(PROGRAM_VERSION)
+	// } else { // Query Packet
+	// 	pkt.SetCommand(cmd)
+	// }
+
+	if _, err := pkt.DoCRC32(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// todo return error as well
+func ReceivePacketV2(conn net.Conn, pkt_std *nrpePacketCommonHeader) (NrpePacket, error) {
+	pkt_recv := new(nrpePacketV2)
+	pkt_recv.Header.Common.PacketVersion = pkt_std.PacketVersion
+	pkt_recv.Header.Common.PacketType = pkt_std.PacketType
+	pkt_recv.Header.Common.CRC32Value = pkt_std.CRC32Value
+	pkt_recv.Header.Common.ResultCode = pkt_std.ResultCode
+	if err := binary.Read(conn, binary.BigEndian, &pkt_recv.Header.CommandBuffer); err != nil {
+		return pkt_recv, err
+	}
+	if err := binary.Read(conn, binary.BigEndian, &pkt_recv.Header.Trailer); err != nil {
+		return pkt_recv, err
+	}
+
+	return pkt_recv, nil
+}
+
+// ************************************************************************************
+func MakeNrpePacket(cmd string, pkt_type int16, pkt_version int) (NrpePacket, error) {
+	var pkt NrpePacket
+
+	if pkt_version == NRPE_PACKET_VERSION_3 || pkt_version == NRPE_PACKET_VERSION_4 {
+		length := len(cmd)
+		dataLen := length
+
+		if length >= MAX_PACKETBUFFER_V3_LENGTH {
+			length = MAX_PACKETBUFFER_V3_LENGTH - 1
+			dataLen = length
+		} else if length < MAX_PACKETBUFFER_V2_LENGTH {
+			dataLen = MAX_PACKETBUFFER_V2_LENGTH
+		}
+		// pktLen := int(reflect.TypeOf(pkt.Packet).Size())
+		// pkt.All = make([]byte, pktLen + dataLen)
+		commandBuffer := make([]byte, dataLen)
+
+		pkt_v3 := new(nrpePacketV3)
+		pkt_v3.Header.Common.PacketVersion = NRPE_PACKET_VERSION_4
+		pkt_v3.Header.Common.CRC32Value = 0
+		pkt_v3.Header.Common.ResultCode = STATE_UNKNOWN
+		pkt_v3.Header.Alignment = 0
+		pkt_v3.Header.BufferLength = uint32(dataLen)
+
+		pkt_v3.CommandBuffer = commandBuffer
+		for i := range pkt_v3.CommandBuffer {
+			pkt_v3.CommandBuffer[i] = '\x00'
+		}
+		pkt = pkt_v3
+	} else {
+		pkt_v2 := new(nrpePacketV2)
+		pkt_v2.Encode()
+
+		// can't imagine what usage it has ?
+		// set random data into the packet field, then set each field to a value or \x00...
+		// so directly set each field to their value ?!
+		// char := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+		// rand.Seed(time.Now().UTC().UnixNano())
+		// for i := 0; i < len(pkt_v2.AllBytes); i++ {
+		// 	pkt_v2.AllBytes[i] = char[rand.Intn(len(char)-1)]
+		// }
+		// if err := binary.Read(bytes.NewReader(pkt_v2.AllBytes), binary.BigEndian, pkt_v2.Header); err != nil {
+		// 	return pkt_v2, err
+		// }
+
+		for i := range pkt_v2.Header.CommandBuffer {
+			pkt_v2.Header.CommandBuffer[i] = '\x00'
+		}
+
+		pkt_v2.Header.Common.PacketVersion = NRPE_PACKET_VERSION_2
+		pkt_v2.Header.Common.CRC32Value = 0
+		pkt_v2.Header.Common.ResultCode = STATE_UNKNOWN
+		pkt_v2.Header.Trailer = 0
+		pkt = pkt_v2
+	}
+
+	pkt.SetType(QUERY_PACKET)
+	pkt.SetResultCode(STATE_OK)
+
+	if pkt_type == RESPONSE_PACKET && (cmd == HELLO_COMMAND || cmd == EMPTY_COMMAND) { //its a response
+		pkt.SetCommand(PROGRAM_VERSION)
+	} else if cmd != "" { // Query Packet
+		pkt.SetCommand(cmd)
+	}
+
+	return pkt, nil
+}
+
+func ReceivePacket(conn net.Conn) (NrpePacket, error) {
+	var pkt_recv NrpePacket
+	pkt_std := new(nrpePacketCommonHeader)
+	if err := binary.Read(conn, binary.BigEndian, pkt_std); err != nil {
+		return pkt_recv, err
+	}
+
+	if pkt_std.PacketVersion == NRPE_PACKET_VERSION_2 {
+		return ReceivePacketV2(conn, pkt_std)
+	} else if pkt_std.PacketVersion == NRPE_PACKET_VERSION_3 || pkt_std.PacketVersion == NRPE_PACKET_VERSION_4 {
+		return ReceivePacketV3(conn, pkt_std)
+	} else {
+		return pkt_recv, fmt.Errorf("invalid nrpe packet version %d", pkt_std.PacketVersion)
+	}
+}
+
+func CheckError(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Fatal error: %s", err.Error())
+		os.Exit(1)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,20 @@
 module github.com/canonical/nrped
 
-go 1.16
+go 1.18
 
 require (
 	github.com/droundy/goopt v0.0.0-20170604162106-0b8effe182da
 	github.com/jimlawless/cfg v0.0.0-20160326141742-136e0c264d31
+	github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a
+)
+
+require (
+	github.com/go-kit/log v0.2.1
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
+)
+
+require (
+	github.com/prometheus/common v0.42.0
+	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
+	golang.org/x/sys v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,17 @@
 github.com/droundy/goopt v0.0.0-20170604162106-0b8effe182da h1:79H+mNJWOObWrQgbkSvvZ3t/D2lKWaTi9mu/v7fNRvg=
 github.com/droundy/goopt v0.0.0-20170604162106-0b8effe182da/go.mod h1:ytRJ64WkuW4kf6/tuYqBATBCRFUP8X9+LDtgcvE+koI=
+github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
+github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/jimlawless/cfg v0.0.0-20160326141742-136e0c264d31 h1:bg4oHsGjsPxX869hm28e/vWbjemDGB6b9PwINRtnEkE=
 github.com/jimlawless/cfg v0.0.0-20160326141742-136e0c264d31/go.mod h1:9qhdPWwVn7/FE1L4TF4rMIix5Lyx8ip5WnHpQ3RiPFk=
+github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI1YM=
+github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
+github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a h1:/eS3yfGjQKG+9kayBkj0ip1BGhq6zJ3eaVksphxAaek=
+github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7AyxJNCJ7SBZ1MfVQCWD6Uqo2oubI2Eq2y2eqf+A5r0=
+github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=
+github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/main.go
+++ b/main.go
@@ -2,13 +2,22 @@ package main
 
 import (
 	"fmt"
+	"strings"
+
+	"net"
+	"os"
+
 	"github.com/canonical/nrped/common"
 	"github.com/canonical/nrped/drop_privilege"
 	"github.com/canonical/nrped/read_config"
 	"github.com/droundy/goopt"
-	"net"
-	"os"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/common/promlog"
+	"github.com/spacemonkeygo/openssl"
 )
+
+var logger log.Logger
 
 func main() {
 
@@ -24,41 +33,100 @@ func main() {
 		[]string{"foreground", "daemon", "systemd"}, "operating mode")
 	goopt.Parse(nil)
 
+	lvl := new(promlog.AllowedLevel)
+	lvl.Set("info")
+	logConfig := promlog.Config{
+		Level: lvl,
+	}
+	logger = promlog.New(&logConfig)
+
 	//implement different run modes..
-	fmt.Println(*run_mode)
+	level.Info(logger).Log("msg", "config", "run_mode", *run_mode, "status", "not implemented!")
+
+	level.Info(logger).Log("msg", "reading config file...")
 	config_obj := new(read_config.ReadConfig)
 	config_obj.Init(*config_file)
 	err := config_obj.ReadConfigFile()
-	common.CheckError(err)
+	if err != nil {
+		level.Error(logger).Log("msg", err)
+		os.Exit(1)
+	}
+	err = config_obj.ReadDefaultParamters()
+	if err != nil {
+		level.Error(logger).Log("msg", err)
+		os.Exit(1)
+	}
+
+	if config_obj.Debug {
+		lvl.Set("debug")
+		logger = promlog.New(&logConfig)
+	}
+
+	level.Info(logger).Log("msg", "config", "debug", config_obj.Debug)
+	service := net.JoinHostPort(config_obj.Server, config_obj.ServerPort)
+	if config_obj.Server == "*" {
+		service = net.JoinHostPort("0.0.0.0", config_obj.ServerPort)
+	}
+	level.Info(logger).Log("msg", "config", "listen", service)
+	level.Info(logger).Log("msg", "config", "transport_mode", config_obj.TransportMode, "status", "not implemented!")
+
+	level.Info(logger).Log("msg", "config", "nrpe_user", config_obj.Nrpe_user, "nrpe_group", config_obj.Nrpe_group)
+	level.Info(logger).Log("msg", "config", "nasty_chars", config_obj.NastyMetachars)
+	level.Info(logger).Log("msg", "config", "AllowCommandArgs", config_obj.CommandArgs)
+
 	//extract the commands command[cmd_name] = "/bin/foobar"
 	config_obj.ReadCommands()
-	config_obj.ReadPrivileges()
+	if config_obj.Debug {
+		for cmd_name, cmd := range config_obj.AllowedCommands {
+			level.Debug(logger).Log("msg", "config", "command", cmd_name, "params", strings.Join(append([]string{cmd.Name}, cmd.Args...), " "))
+		}
+	}
+	config_obj.ReadAllowedHosts()
+	if config_obj.Debug {
+		for _, netw := range config_obj.AllowedHosts {
+			level.Debug(logger).Log("msg", "config allow", "net", netw.String())
+		}
+	}
+
+	// config_obj.ReadPrivileges()
 	//TODO check for errors
 	//what we gonna do with the group?
 	pwd := drop_privilege.Getpwnam(config_obj.Nrpe_user)
 	drop_privilege.DropPrivileges(int(pwd.Uid), int(pwd.Gid))
-	//we have to read it from config
-	service := ":5666"
-	err = setupSocket(4, service, config_obj)
-	common.CheckError(err)
+	err = setupSocket(service, config_obj)
+	if err != nil {
+		level.Error(logger).Log("msg", err)
+		os.Exit(1)
+	}
 }
 
-func setupSocket(socket_version int, service string, config_obj *read_config.ReadConfig) error {
+func setupSocket(service string, config_obj *read_config.ReadConfig) error {
+	var listener net.Listener
+	var err error
 
-	socket_type := "tcp4"
-
-	if socket_version == 6 {
-		socket_type = "tcp6"
+	switch config_obj.TransportMode {
+	case 0:
+		listener, err = net.Listen("tcp", service)
+	case 1:
+		var ctx *openssl.Ctx
+		ctx, err = openssl.NewCtx()
+		if err != nil {
+			err = fmt.Errorf("error creating SSL context: %s", err)
+			return err
+		}
+		// err = ctx.SetCipherList("ALL:!MD5:@STRENGTH")
+		err = ctx.SetCipherList("ALL:!MD5:@STRENGTH:@SECLEVEL=0")
+		if err != nil {
+			err = fmt.Errorf("error setting SSL cipher list: %s", err)
+			return err
+		}
+		listener, err = openssl.Listen("tcp", service, ctx)
 	}
-
-	tcpAddr, err := net.ResolveTCPAddr(socket_type, service)
-	common.CheckError(err)
-
-	listener, err := net.ListenTCP("tcp", tcpAddr)
 
 	if err != nil {
 		return err
 	}
+	level.Info(logger).Log("msg", "nrped waiting for connection")
 
 	for {
 		if conn, err := listener.Accept(); err != nil {
@@ -75,30 +143,72 @@ func setupSocket(socket_version int, service string, config_obj *read_config.Rea
 func handleClient(conn net.Conn, config_obj *read_config.ReadConfig) {
 	// close connection on exit
 	defer conn.Close()
-	pkt_rcv, _ := common.ReceivePacket(conn)
 
-	cmd := string(pkt_rcv.CommandBuffer[:common.GetLen(pkt_rcv.CommandBuffer[:])])
-	pkt_rcv_crc32value := pkt_rcv.CRC32Value
-
-	if crc32, _ := common.DoCRC32(&pkt_rcv); crc32 != pkt_rcv_crc32value {
-		fmt.Println("WARNING: CRC not matching", crc32, pkt_rcv_crc32value)
+	level.Debug(logger).Log("msg", "new connection from", "ip", conn.RemoteAddr())
+	if config_obj.IsHostAllowed(conn.RemoteAddr().(*net.TCPAddr).IP) {
+		level.Debug(logger).Log("msg", "host is allowed list")
+	} else {
+		level.Warn(logger).Log("msg", "host is not allowed list")
+		return
+	}
+	// if addr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+	// 	fmt.Println(addr.IP.String())
+	// }
+	pkt_rcv, err := common.ReceivePacket(conn)
+	if err != nil {
+		level.Error(logger).Log("msg", err)
+		return
 	}
 
-	pkt_send := common.PrepareToSend(cmd, common.RESPONSE_PACKET)
+	cmdline := pkt_rcv.GetCommandBuffer()
 
-	if pkt_send.ResultCode == common.STATE_UNKNOWN { //its a response, but not to the HELLO_COMMAND
-		if config_obj.IsCommandAllowed(cmd) {
-			str_cmd := config_obj.GetCommand(cmd)
-			fmt.Println("executing:", str_cmd)
-			return_id, return_stdout := common.ExecuteCommand(str_cmd)
-			pkt_send.ResultCode = return_id
-			copy(pkt_send.CommandBuffer[:], return_stdout)
-			pkt_send.CRC32Value, _ = common.DoCRC32(&pkt_send)
-		} else {
-			pkt_send.ResultCode = common.STATE_CRITICAL
+	pkt_rcv_crc32value := pkt_rcv.GetCRC32()
+
+	if crc32, _ := pkt_rcv.DoCRC32(); crc32 != pkt_rcv_crc32value {
+		level.Warn(logger).Log("msg", "CRC not matching", "crc32_received", pkt_rcv_crc32value, "crc32_computed", crc32)
+		return
+	}
+
+	pkt_send, err := common.MakeNrpePacket("", common.RESPONSE_PACKET, int(pkt_rcv.Version()))
+	if err != nil {
+		level.Error(logger).Log("msg", err)
+		os.Exit(common.STATE_UNKNOWN)
+	}
+
+	cmd := common.CommandLine2Cmd(cmdline)
+	level.Debug(logger).Log("msg", "new query received", "command", cmd.Name, "params", strings.Join(cmd.Args, " "))
+	if len(cmd.Args) > 0 && !config_obj.CommandArgs {
+		level.Warn(logger).Log("msg", "command args are not allowed '(check dont_blame_nrpe config argument)'")
+		pkt_send.SetResultCode(common.STATE_UNKNOWN)
+		goto send_result
+	}
+
+	//its a response, but not to the HELLO_COMMAND
+	if cmd.Name == common.HELLO_COMMAND {
+		level.Debug(logger).Log("msg", "sending banner")
+		pkt_send.SetCommand(common.PROGRAM_VERSION)
+	} else if cmd.Name == common.EMPTY_COMMAND {
+		level.Debug(logger).Log("msg", "sending banner")
+		pkt_send.SetCommand(fmt.Sprintf("NRPED GO v%s", common.PROGRAM_VERSION))
+	} else {
+		cfg_cmd, err := config_obj.GetCommand(cmd.Name)
+		if err != nil {
+			level.Info(logger).Log("msg", "command '%s' not found'", cmd.Name)
+			pkt_send.SetResultCode(common.STATE_UNKNOWN)
+			goto send_result
 		}
+		return_id, return_stdout := cfg_cmd.Execute(cmd, config_obj.NastyMetachars, logger)
+		pkt_send.SetResultCode(return_id)
+		pkt_send.SetCommand(string(return_stdout))
 	}
 
-	err := common.SendPacket(conn, pkt_send)
-	common.CheckError(err)
+send_result:
+	if err := pkt_send.PrepareToSend(common.RESPONSE_PACKET); err != nil {
+		level.Error(logger).Log("msg", err)
+	}
+
+	err = pkt_send.SendPacket(conn)
+	if err != nil {
+		level.Error(logger).Log("msg", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 		service = net.JoinHostPort("0.0.0.0", config_obj.ServerPort)
 	}
 	level.Info(logger).Log("msg", "config", "listen", service)
-	level.Info(logger).Log("msg", "config", "transport_mode", config_obj.TransportMode, "status", "not implemented!")
+	level.Info(logger).Log("msg", "config", "transport_mode", config_obj.TransportMode)
 
 	level.Info(logger).Log("msg", "config", "nrpe_user", config_obj.Nrpe_user, "nrpe_group", config_obj.Nrpe_group)
 	level.Info(logger).Log("msg", "config", "nasty_chars", config_obj.NastyMetachars)
@@ -193,7 +193,7 @@ func handleClient(conn net.Conn, config_obj *read_config.ReadConfig) {
 	} else {
 		cfg_cmd, err := config_obj.GetCommand(cmd.Name)
 		if err != nil {
-			level.Info(logger).Log("msg", "command '%s' not found'", cmd.Name)
+			level.Info(logger).Log("msg", "command not found", "command", cmd.Name)
 			pkt_send.SetResultCode(common.STATE_UNKNOWN)
 			goto send_result
 		}

--- a/nrpe.cfg
+++ b/nrpe.cfg
@@ -29,7 +29,7 @@ pid_file=/var/run/nrpe.pid
 # 0 = CLEAR TEXT
 # 1 = SSL
 # 2 = SSH
-transport_mode=0
+transport_mode=1
 
 # PORT NUMBER
 # Port number we should wait for connections on.
@@ -46,6 +46,7 @@ server_port=5666
 # NOTE: This option is ignored if NRPE is running under either inetd or xinetd
 
 #server_address=127.0.0.1
+server_address=*
 
 
 
@@ -98,7 +99,7 @@ allowed_hosts=127.0.0.1
 #
 # Values: 0=do not allow arguments, 1=allow command arguments
 
-dont_blame_nrpe=0
+dont_blame_nrpe=1
 
 
 
@@ -146,7 +147,7 @@ allow_bash_command_substitution=0
 # syslog facility.
 # Values: 0=debugging off, 1=debugging on
 
-debug=0
+debug=1
 
 
 
@@ -206,6 +207,12 @@ server_certificate_path=/etc/nrped/ca.pem
 server_certificate_key_path=/etc/nrped/ca.key
 
 
+# NASTY METACHARACTERS
+# This option allows you to override the list of characters that cannot
+# be passed to the NRPE daemon.
+
+# nasty_metachars=|`&><'\\[]{};\r\n
+
 
 # COMMAND DEFINITIONS
 # Command definitions that this daemon will run.  Definitions
@@ -230,7 +237,8 @@ server_certificate_key_path=/etc/nrped/ca.key
 # The following examples use hardcoded command arguments...
 
 #command[check_users]=/usr/local/nagios/lib/check_users -w 5 -c 10
-#command[check_load]=/usr/local/nagios/lib/check_load -w 15,10,5 -c 30,25,20
+command[check_load]=/usr/local/nagios/libexec/check_load -w 15,10,5 -c 30,25,20
+command[check_all_filesystems]=/usr/local/nagios/libexec/check_disk -w 20% -c 10% --errors-only --local --all
 #command[check_hda1]=/usr/local/nagios/lib/check_disk -w 20% -c 10% -p /dev/hda1
 #command[check_zombie_procs]=/usr/local/nagios/lib/check_procs -w 5 -c 10 -s Z
 #command[check_total_procs]=/usr/local/nagios/lib/check_procs -w 150 -c 200
@@ -244,5 +252,6 @@ command[check_iostat]=/usr/local/nagios/lib/check_iostat -d sda -c 15,15,15 -w 1
 
 #command[check_users]=/usr/local/nagios/lib/check_users -w $ARG1$ -c $ARG2$
 #command[check_load]=/usr/local/nagios/lib/check_load -w $ARG1$ -c $ARG2$
-#command[check_disk]=/usr/local/nagios/lib/check_disk -w $ARG1$ -c $ARG2$ -p $ARG3$
+#command[check_disk]=/usr/local/nagios/lib/check_disk $ARG1$ -c $ARG2$ -p $ARG3$
 #command[check_procs]=/usr/local/nagios/lib/check_procs -w $ARG1$ -c $ARG2$ -s $ARG3$
+command[check_disk]=/usr/local/nagios/libexec/check_disk $ARG1$

--- a/read_config/nrpe-test.cfg
+++ b/read_config/nrpe-test.cfg
@@ -81,7 +81,7 @@ nrpe_group=nagios
 #
 # NOTE: This option is ignored if NRPE is running under either inetd or xinetd
 
-allowed_hosts=127.0.0.1
+allowed_hosts=127.0.0.1,::1
 
 
 
@@ -195,6 +195,12 @@ connection_timeout=300
 #include_dir=<somedirectory>
 #include_dir=<someotherdirectory>
 
+
+# NASTY METACHARACTERS
+# This option allows you to override the list of characters that cannot
+# be passed to the NRPE daemon.
+
+# nasty_metachars=|`&><'\\[]{};\r\n
 
 
 # COMMAND DEFINITIONS

--- a/read_config/read_config.go
+++ b/read_config/read_config.go
@@ -2,9 +2,13 @@ package read_config
 
 import (
 	"fmt"
-	"github.com/jimlawless/cfg"
+	"net"
 	"strconv"
 	"strings"
+
+	"github.com/canonical/nrped/common"
+
+	"github.com/jimlawless/cfg"
 )
 
 const (
@@ -12,25 +16,27 @@ const (
 )
 
 type ReadConfig struct {
-	AllowedCommands map[string]string
+	AllowedCommands map[string]*common.NrpeCommand
 	FileName        string
-	ServerPort      uint16
+	ServerPort      string
 	TransportMode   uint16
 	CommandPrefix   string
 	Server          string
-	AllowedHosts    [MAX_ALLOWED_HOSTS]string
+	AllowedHosts    []*net.IPNet
 	Debug           bool
 	Nrpe_user       string
 	Nrpe_group      string
 	PidFile         string
 	ConfigMap       map[string]string
 	//TODO implement everything
+	CommandArgs    bool
+	NastyMetachars string
 }
 
-//TODO
-//design a constructor
+// TODO
+// design a constructor
 func (rc *ReadConfig) Init(file_name string) {
-	rc.AllowedCommands = make(map[string]string)
+	rc.AllowedCommands = make(map[string]*common.NrpeCommand)
 	rc.ConfigMap = make(map[string]string)
 	rc.FileName = file_name
 }
@@ -41,27 +47,93 @@ func (rc *ReadConfig) ReadConfigFile() error {
 	}
 	return nil
 }
+func (rc *ReadConfig) ReadDefaultParamters() error {
 
-func (rc *ReadConfig) ReadTransportMode() {
-	for key, value := range rc.ConfigMap {
-		if key == "transport_mode" {
-			s, _ := strconv.Atoi(value)
-			rc.TransportMode = uint16(s)
-		}
+	val, ok := rc.ConfigMap["server_address"]
+	if !ok {
+		val = "127.0.0.1"
 	}
+	rc.Server = val
+	// level.Info(logger).Log("msg", "")
+
+	val, ok = rc.ConfigMap["server_port"]
+	if !ok {
+		val = "5666"
+	}
+	rc.ServerPort = val
+
+	if val, ok := rc.ConfigMap["transport_mode"]; ok {
+		s, err := strconv.Atoi(val)
+		if err != nil {
+			return err
+		}
+		rc.TransportMode = uint16(s)
+	} else {
+		rc.TransportMode = uint16(0)
+	}
+
+	val, ok = rc.ConfigMap["nrpe_user"]
+	if !ok {
+		val = "nagios"
+	}
+	rc.Nrpe_user = val
+
+	val, ok = rc.ConfigMap["nrpe_group"]
+	if !ok {
+		val = "nagios"
+	}
+	rc.Nrpe_group = val
+
+	if val, ok := rc.ConfigMap["debug"]; ok {
+		s, err := strconv.Atoi(val)
+		if err != nil {
+			return err
+		}
+		if s != 0 {
+			rc.Debug = true
+		} else {
+			rc.Debug = false
+		}
+	} else {
+		rc.Debug = false
+	}
+
+	if val, ok := rc.ConfigMap["dont_blame_nrpe"]; ok {
+		s, err := strconv.Atoi(val)
+		if err != nil {
+			return err
+		}
+		if s != 0 {
+			rc.CommandArgs = true
+		} else {
+			rc.CommandArgs = false
+		}
+	} else {
+		rc.CommandArgs = false
+	}
+
+	val, ok = rc.ConfigMap["nasty_metachars"]
+	if !ok {
+		val = "|`&><'\\[]{};\r\n"
+	}
+	rc.NastyMetachars = val
+
+	return nil
 }
+
+/* parse commands from config file and build a list of valid NrpeCommand */
 func (rc *ReadConfig) ReadCommands() {
 	for key, value := range rc.ConfigMap {
 		if strings.HasPrefix(key, "command[") {
 			init_str := strings.Index(key, "[")
 			end_str := strings.Index(key, "]")
-			fmt.Println(key[init_str+1 : end_str])
-			rc.AllowedCommands[key[init_str+1:end_str]] = value
+			cmd := common.BuildNrpeCommand(value)
+			rc.AllowedCommands[key[init_str+1:end_str]] = &cmd
 		}
 	}
 }
 
-//TODO, for every option, loop through the ConfigMap? hm refactor it ASAP
+// TODO, for every option, loop through the ConfigMap? hm refactor it ASAP
 func (rc *ReadConfig) ReadPrivileges() {
 	for key, value := range rc.ConfigMap {
 		switch key {
@@ -73,17 +145,62 @@ func (rc *ReadConfig) ReadPrivileges() {
 	}
 }
 
-func (rc *ReadConfig) IsCommandAllowed(cmd string) bool {
-	if _, ok := rc.AllowedCommands[cmd]; ok {
-		return true
-	} else {
-		return false
+/*
+	 check if command identified by cmd is referenced in list of allowed commands obtained from config file.
+		return:
+		  pointer to valid NrpeCommand if found
+		  nil and "not found error" else.
+*/
+func (rc *ReadConfig) GetCommand(cmd string) (*common.NrpeCommand, error) {
+	var val *common.NrpeCommand
+	ok := false
+	if val, ok = rc.AllowedCommands[cmd]; ok {
+		return val, nil
+	}
+	return val, fmt.Errorf("command not found")
+}
+
+/* Parse allowed_hosts config line to obtain a list of IP and network that can be check on connection.
+ */
+func (rc *ReadConfig) ReadAllowedHosts() {
+	ip_list, ok := rc.ConfigMap["allowed_hosts"]
+	if !ok {
+		ip_list = "127.0.0.1"
+	}
+	ip_lists := strings.Split(ip_list, ",")
+	// rc.AllowedHosts = make([]*net.IPNet, len(ip_lists))
+	for _, ip_str := range ip_lists {
+		ip_str = strings.Trim(ip_str, " ")
+		if !strings.Contains(ip_str, "\\") {
+			if !strings.Contains(ip_str, ":") {
+				ip_str = fmt.Sprintf("%s/32", ip_str)
+			} else {
+				ip_str = fmt.Sprintf("%s/64", ip_str)
+			}
+		}
+		_, net, err := net.ParseCIDR(ip_str)
+		if err == nil {
+			rc.AllowedHosts = append(rc.AllowedHosts, net)
+		}
 	}
 }
 
-func (rc *ReadConfig) GetCommand(cmd string) string {
-	if val, ok := rc.AllowedCommands[cmd]; ok {
-		return val
+/*
+check if ip is in allowed hosts
+loop on all networks computed from allowed_hosts lists
+checking if input ip address is contained in
+return:
+
+	true if found a valid network
+	false else
+*/
+func (rc *ReadConfig) IsHostAllowed(ip net.IP) bool {
+	res := false
+	for _, network := range rc.AllowedHosts {
+		if network.Contains(ip) {
+			res = true
+			break
+		}
 	}
-	return ""
+	return res
 }


### PR DESCRIPTION
# Changes
This is my contribution to nrped module.
Features:
* add v3 v4 packet support. Allow to receive buffer larger that 1024 bytes.
* add command args support in both nrped and check_nrpe.
* allow to select packet version in check_nrpe command
* add support for ssl (openssl not tls!) in check_nrpe and nrped.
* add support in nrped by config file for:
  * dont_blame_nrpe : cmd args are allowed or not.
  * server_address, server_port 
  * transport (clear, openssl)
  * allowed_hosts
  * login : debug set level to debug. else info.
  * check nasty_char for command parameters
  
# Usage:
  This module updates are required for a new version (Pull Request) of nrpe_exporter.
  It will provide the hability to used performance data generated by check.

# Details
NRPED when transport=1 is set in config, is now compatible with check_nrpe nagios "official" client:

* **packets** are compatible with version 2, 3 and 4.
connections are on go nrped.

```bash
usr/local/nagios/libexec/check_nrpe -V
NRPE Plugin for Nagios
Version: 4.1.0

$ /usr/local/nagios/libexec/check_nrpe -H 127.0.0.1 -2 -c check_load
OK - Charge moyenne: 0.04, 0.05, 0.04|load1=0.040;15.000;30.000;0; load5=0.050;10.000;25.000;0; load15=0.040;5.000;20.000;0; 
$ /usr/local/nagios/libexec/check_nrpe -H 127.0.0.1 -3 -c check_load
OK - Charge moyenne: 0.04, 0.05, 0.04|load1=0.040;15.000;30.000;0; load5=0.050;10.000;25.000;0; load15=0.040;5.000;20.000;0; 
$ /usr/local/nagios/libexec/check_nrpe -H 127.0.0.1  -c check_load
OK - Charge moyenne: 0.04, 0.05, 0.04|load1=0.040;15.000;30.000;0; load5=0.050;10.000;25.000;0; load15=0.040;5.000;20.000;0; 
```
* **allow command args**: (dont_blame_nrpe=1 set)

```bash
$ /usr/local/nagios/libexec/check_nrpe -H 127.0.0.1  -c check_disk -a "-w5% -c3% --all -X cgroup -X iso9660 -X tmpfs -X devtmpfs -X autofs -X cgroup"
DISK OK - free space: / 230214 MiB (95,30% inode=100%); /boot 594 MiB (58,65% inode=100%); /home 245677 MiB (94,50% inode=99%);| /=11331MiB;229468;234299;0;241546 /boot=419MiB;963;983;0;1014 /home=14289MiB;246968;252167;0;259967
$ 
```

* **check nasty_chars**:

```bash
$ /usr/local/nagios/libexec/check_nrpe -H 127.0.0.1  -c check_disk -a "-w5% -c3% --all -X cgroup -X iso9660 -X tmpfs -X devtmpfs -X autofs -X cgroup; cat /etc/shadow"
nasty chars found
$ /usr/local/nagios/libexec/check_nrpe -H 127.0.0.1  -c check_disk -a "-w5% -c3% --all -X cgroup -X iso9660 -X tmpfs -X devtmpfs -X autofs -X cgroup; kill -09 1"
nasty chars found
$ 
```

* **allow_hosts** check (allowed_hosts set only to 127.0.0.1)

```bash
$ /usr/local/nagios/libexec/check_nrpe -H 192.168.122.1  -c check_load
CHECK_NRPE: Error - Could not connect to 192.168.122.1: Connection reset by peer
$ 
```


* Server trace (debug = 1 set )

```log
ts=2023-04-27T15:10:16.557Z caller=main.go:147 level=debug msg="new connection from" ip=127.0.0.1:39984
ts=2023-04-27T15:10:16.557Z caller=main.go:149 level=debug msg="host is allowed list"
ts=2023-04-27T15:10:16.558Z caller=main.go:179 level=debug msg="new query received" command=check_load params=
ts=2023-04-27T15:10:16.558Z caller=command.go:94 level=debug msg="will launch command" cmd="/usr/local/nagios/libexec/check_load -w 15,10,5 -c 30,25,20"
ts=2023-04-27T15:10:16.565Z caller=command.go:108 level=debug msg="command execute successfully" exit_code=0 stdout="OK - Charge moyenne: 0.00, 0.08, 0.12|load1=0.000;15.000;30.000;0; load5=0.080;10.000;25.000;0; load15=0.120;5.000;20.000;0; "
ts=2023-04-27T15:10:44.120Z caller=main.go:147 level=debug msg="new connection from" ip=127.0.0.1:56652
ts=2023-04-27T15:10:44.120Z caller=main.go:149 level=debug msg="host is allowed list"
ts=2023-04-27T15:10:44.122Z caller=main.go:179 level=debug msg="new query received" command=check_load params=
ts=2023-04-27T15:10:44.122Z caller=command.go:94 level=debug msg="will launch command" cmd="/usr/local/nagios/libexec/check_load -w 15,10,5 -c 30,25,20"
ts=2023-04-27T15:10:44.128Z caller=command.go:108 level=debug msg="command execute successfully" exit_code=0 stdout="OK - Charge moyenne: 0.00, 0.07, 0.11|load1=0.000;15.000;30.000;0; load5=0.070;10.000;25.000;0; load15=0.110;5.000;20.000;0; "
ts=2023-04-27T15:10:55.316Z caller=main.go:147 level=debug msg="new connection from" ip=127.0.0.1:38946
ts=2023-04-27T15:10:55.316Z caller=main.go:149 level=debug msg="host is allowed list"
ts=2023-04-27T15:10:55.317Z caller=main.go:179 level=debug msg="new query received" command=check_load params="`cat /etc/shadow`"
ts=2023-04-27T15:10:55.317Z caller=command.go:94 level=debug msg="will launch command" cmd="/usr/local/nagios/libexec/check_load -w 15,10,5 -c 30,25,20"
ts=2023-04-27T15:10:55.323Z caller=command.go:108 level=debug msg="command execute successfully" exit_code=0 stdout="OK - Charge moyenne: 0.00, 0.07, 0.11|load1=0.000;15.000;30.000;0; load5=0.070;10.000;25.000;0; load15=0.110;5.000;20.000;0; "
ts=2023-04-27T15:11:45.733Z caller=main.go:147 level=debug msg="new connection from" ip=127.0.0.1:43722
ts=2023-04-27T15:11:45.733Z caller=main.go:149 level=debug msg="host is allowed list"
ts=2023-04-27T15:11:45.734Z caller=main.go:179 level=debug msg="new query received" command=check_disk params="-w5% -c3% --all -X cgroup -X iso9660 -X tmpfs -X devtmpfs -X autofs -X cgroup"
ts=2023-04-27T15:11:45.734Z caller=command.go:94 level=debug msg="will launch command" cmd="/usr/local/nagios/libexec/check_disk -w5% -c3% --all -X cgroup -X iso9660 -X tmpfs -X devtmpfs -X autofs -X cgroup"
ts=2023-04-27T15:11:45.737Z caller=command.go:108 level=debug msg="command execute successfully" exit_code=0 stdout="DISK OK - free space: / 230214 MiB (95,30% inode=100%); /boot 594 MiB (58,65% inode=100%); /home 245677 MiB (94,50% inode=99%);| /=11331MiB;229468;234299;0;241546 /boot=419MiB;963;983;0;1014 /home=14289MiB;246968;252167;0;259967"
ts=2023-04-27T15:12:08.071Z caller=main.go:147 level=debug msg="new connection from" ip=192.168.122.1:43204
ts=2023-04-27T15:12:08.071Z caller=main.go:151 level=warn msg="host is not allowed list"
ts=2023-04-27T15:12:47.036Z caller=main.go:147 level=debug msg="new connection from" ip=127.0.0.1:44152
ts=2023-04-27T15:12:47.036Z caller=main.go:149 level=debug msg="host is allowed list"
ts=2023-04-27T15:12:47.037Z caller=main.go:179 level=debug msg="new query received" command=check_disk params="-w5% -c3% --all -X cgroup -X iso9660 -X tmpfs -X devtmpfs -X autofs -X cgroup; cat /etc/shadow"
ts=2023-04-27T15:12:47.037Z caller=command.go:81 level=debug msg="command parameter contains nasty chars" index=0 param="-w5% -c3% --all -X cgroup -X iso9660 -X tmpfs -X devtmpfs -X autofs -X cgroup; cat /etc/shadow"
```

check_nrpe is compatible with nrpe v 4.10.0 official.

**check_nrpe** usage examples:

```bash
$ bin/check_nrpe --version
0.0.3

$ bin/check_nrpe -H 127.0.0.1 -t 1 -c check_load
OK - Charge moyenne: 0.14, 0.21, 0.23|load1=0.140;15.000;30.000;0; load5=0.210;10.000;25.000;0; load15=0.230;5.000;20.000;0; 

bin/check_nrpe -H 127.0.0.1 -t 1 -c check_disk -- -w5% -c3% --all -X cgroup -X iso9660 -X tmpfs -X devtmpfs -X autofs -X cgroup
DISK OK - free space: / 230214 MiB (95,30% inode=100%); /boot 594 MiB (58,65% inode=100%); /home 245677 MiB (94,50% inode=99%);| /=11331MiB;229468;234299;0;241546 /boot=419MiB;963;983;0;1014 /home=14289MiB;246968;252167;0;259967

$ bin/check_nrpe -H 127.0.0.1 -t 1 -c check_unknown; echo $?

3
$ bin/check_nrpe -H 127.0.0.1 -t 1 -c check_iostat; echo $?
fork/exec /usr/local/nagios/lib/check_iostat: no such file or directory
2
```

